### PR TITLE
[add] github actions

### DIFF
--- a/.github/workflows/mac_ci.yml
+++ b/.github/workflows/mac_ci.yml
@@ -1,0 +1,36 @@
+name: mac_ci
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install requirements
+      run: |
+        cd joke_engine
+        pip install -r lib/requirements.txt
+    - name: Run Test
+      run: |
+        cd joke_engine
+        python manage.py test

--- a/.github/workflows/ubuntu_ci.yml
+++ b/.github/workflows/ubuntu_ci.yml
@@ -1,0 +1,36 @@
+name: ubuntu_ci
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install requirements
+      run: |
+        cd joke_engine
+        pip install -r lib/requirements.txt
+    - name: Run Test
+      run: |
+        cd joke_engine
+        python manage.py test

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -1,0 +1,36 @@
+name: windows_ci
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install requirements
+      run: |
+        cd joke_engine
+        pip install -r lib/requirements.txt
+    - name: Run Test
+      run: |
+        cd joke_engine
+        python manage.py test


### PR DESCRIPTION
# 概要 - Overview
GitHub actionsを使い、Mac、Windows、Ubuntuのテスト環境下での単体テストを追加します。
（やることはtravisと一緒）

# 変更内容 - Changes
github-actionsのyml記述のみ

# 影響範囲 - Impact range
ciの実行時間がOSによって遅かったり早かったりします。

# 動作要件 - Operating requirements
GitHub

# 補足 - Supplement
travisだとWindowsのテストができないです。
